### PR TITLE
RM: do not run bechmarking on push

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,7 +2,6 @@ name: Benchmark
 
 on:
     pull_request:
-    push:
 
 jobs:
     test:


### PR DESCRIPTION
Closes #14 

But it is actually primarily to see if all is good and benchmarking workflow works on a PR