### PR TITLE
RF benchmarks a bit

### DIFF
--- a/benchmarks/cache.py
+++ b/benchmarks/cache.py
@@ -9,7 +9,15 @@ from morecontext import envset
 from fscacher import PersistentCache
 
 
-class TimeFile:
+class Benchmark:
+    """Common parameters for the benchmarks"""
+    # how many times to rerun for a sample
+    number = 30
+    processes = 1  # do not parallelize
+
+
+class TimeFile(Benchmark):
+
     FILE_SIZE = 1024
     param_names = ["control"]
     params = (["", "ignore"])
@@ -42,7 +50,8 @@ class TimeFile:
         self.cache.clear()
 
 
-class TimeDirectoryFlat:
+class TimeDirectoryFlat(Benchmark):
+
     LAYOUT = (100,)
 
     param_names = ["control", "tmpdir"]

--- a/benchmarks/cache.py
+++ b/benchmarks/cache.py
@@ -9,14 +9,7 @@ from morecontext import envset
 from fscacher import PersistentCache
 
 
-class Benchmark:
-    """Common parameters for the benchmarks"""
-    # how many times to rerun for a sample
-    number = 30
-    processes = 1  # do not parallelize
-
-
-class TimeFile(Benchmark):
+class TimeFile:
 
     FILE_SIZE = 1024
     param_names = ["control"]
@@ -39,18 +32,16 @@ class TimeFile(Benchmark):
             with open(path, "rb") as fp:
                 return sha256(fp.read()).hexdigest()
         self._hashfile = hashfile
-        # Perform initial invocation, so we do not taint actual
-        # timing by invocation of the function
-        self._hashfile_target = hashfile("foo.dat")
 
     def time_file(self, control):
-        assert self._hashfile("foo.dat") == self._hashfile_target
+        for _ in range(100):
+            self._hashfile("foo.dat")
 
     def teardown(self, control):
         self.cache.clear()
 
 
-class TimeDirectoryFlat(Benchmark):
+class TimeDirectoryFlat:
 
     LAYOUT = (100,)
 
@@ -79,10 +70,10 @@ class TimeDirectoryFlat(Benchmark):
                         total_size += e.stat().st_size
             return total_size
         self._dirsize = dirsize
-        self._dirsize_target = dirsize(str(self.dir))
 
     def time_directory(self, control, tmpdir):
-        assert self._dirsize(str(self.dir)) == self._dirsize_target
+        for _ in range(100):
+            self._dirsize(str(self.dir))
 
     def teardown(self, *args, **kwargs):
         self.cache.clear()

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,15 @@ install_requires =
     appdirs == 1.*
     joblib >= 0.17
 
+[options.extras_require]
+benchmarks =
+    asv
+    morecontext
+devel =
+    %(benchmarks)s
+all =
+    %(devel)s
+
 [options.packages.find]
 where = src
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ benchmarks =
     morecontext
 devel =
     %(benchmarks)s
+    pre-commit
 all =
     %(devel)s
 


### PR DESCRIPTION
- I do not see a reason to sweep "number" of tries  (10, 100, 1000) so just choose a middle group (100)
- I have moved "establishing" of the function into `setup` and added its initial invocation so it nohow taints the actual "hot cache" scenario which is what benchmark should primarily measure (since does that in the loop).
   Well `asv` is likely doing benchmark "warm up" but I decided just to make it explicit
- added dependencies as extra requires needed here
- git log has more details and shows more desperate attempts to get some "more" stable estimates.

unfortunately benchmarks are still quite inconsistent, but for #20 they do more frequently point than don't that it seems indeed just made things slower, e.g.
```
(git)lena:~/proj/fscacher[bf-bmarks]git
$> asv run HEAD^-1; asv run origin/gh-19^-1; asv compare HEAD origin/gh-19
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.8-morecontext.
·· Building b4552372 <bf-bmarks> for virtualenv-py3.8-morecontext.
....
asv run origin/gh-19^-1  11.38s user 3.59s system 54% cpu 27.703 total

All benchmarks:

       before           after         ratio
     [b4552372]       [b7b53d3b]
     <bf-bmarks>                 
          231±8ms         277±10ms    ~1.20  cache.TimeDirectoryDeep.time_directory('', '.')
          364±3ms          348±7ms     0.96  cache.TimeDirectoryDeep.time_directory('ignore', '.')
         181±10ms          207±6ms    ~1.15  cache.TimeDirectoryFlat.time_directory('', '.')
         43.6±4ms         42.5±1ms     0.97  cache.TimeDirectoryFlat.time_directory('ignore', '.')
       31.6±0.3ms       31.7±0.7ms     1.01  cache.TimeFile.time_file('')
          1.06±0s          1.06±0s     1.00  cache.TimeFile.time_file('ignore')
```

another observation, since `dirsize` is  pretty much also a walk (recursive) through the tree and summing up the sizes, difference between 'ignore' and '' modes seems to show more or less of how much overhead our caching "logic" adds on top of pure `stat` invocation.  I even wondered if some async implementation could be of some help, but first we just need to profile to see what is taking time.

other spots I have mentioned but did not touch
- create sample file/directory under `.` by default.  IMHO is quite suboptimal -- should use regular tmp. outside specification could precreate temp directory to pass through