### PR TITLE
Resimplify release workflow

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -3,5 +3,13 @@
     "baseBranch": "master",
     "author": "auto <auto@nil>",
     "noVersionPrefix": true,
-    "plugins": ["git-tag"]
+    "plugins": [
+        "git-tag",
+        [
+            "exec",
+            {
+                "afterRelease": "python -m build && twine upload dist/*"
+            }
+        ]
+    ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,6 @@ jobs:
   auto-release:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
-    outputs:
-      auto-version: ${{ steps.auto-version.outputs.version }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -24,54 +22,18 @@ jobs:
           wget -O- "$auto_download_url" | gunzip > ~/auto
           chmod a+x ~/auto
 
-      - name: Check whether a release is due
-        id: auto-version
-        run: |
-          version="$(~/auto version)"
-          echo "::set-output name=version::$version"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create release
-        run: ~/auto shipit
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  pypi:
-    runs-on: ubuntu-latest
-    needs: auto-release
-    if: "needs.auto-release.outputs.auto-version != ''"
-    steps:
-      # By default, actions/checkout will checkout the commit that that was
-      # pushed to master and triggered the workflow, but this does not include
-      # the commit & tag created by `auto`.  In order to get that, we need to
-      # look up the tag for the latest release.
-      - name: Get tag of latest release
-        id: latest-release
-        run: |
-          latest_tag="$(curl -fsSL https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq -r .tag_name)"
-          echo "::set-output name=tag::$latest_tag"
-
-      - name: Checkout source
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ steps.latest-release.outputs.tag }}
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '^3.6'
 
-      - name: Install build & twine
+      - name: Install Python dependencies
         run: python -m pip install build twine
 
-      - name: Build
-        run: python -m build
-
-      - name: Upload
-        run: twine upload dist/*
+      - name: Create release
+        run: ~/auto shipit
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 


### PR DESCRIPTION
This reverts commit 8aff93e88bd8a4a3bc6d0da97c069c9faf1f5cc0.

The original commit was made in an attempt to fix the failing auto+versioneer integration.  The actual problem turned out to be unrelated.