### PR TITLE
Add `exclude_kwargs` to memoization decorators

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,10 @@ non-`path-like object
 <https://docs.python.org/3/glossary.html#term-path-like-object>`_ as the value
 of ``path``, the cache is ignored.
 
+``memoize_path()`` optionally takes an ``exclude_kwargs`` argument, which must
+be a sequence of names of arguments of the decorated function that will be
+ignored for caching purposes.
+
 Caches are stored on-disk and thus persist between Python runs.  To clear a
 given ``PersistentCache`` and erase its data store, call the ``clear()``
 method.

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ package_dir =
 python_requires = >=3.7
 install_requires =
     appdirs == 1.*
-    joblib >= 0.17
+    joblib ~= 1.1
 
 [options.extras_require]
 benchmarks =

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ addopts = --cov=fscacher --no-cov-on-fail
 filterwarnings =
     error
     ignore:The distutils package is deprecated:DeprecationWarning:joblib
+    ignore:`formatargspec` is deprecated:DeprecationWarning:joblib
 norecursedirs = test/data
 
 [coverage:run]


### PR DESCRIPTION
Part of implementing https://github.com/dandi/dandi-cli/issues/400.

Blocked by https://github.com/joblib/joblib/issues/1164 (edit by @yarikoptic: already closed and likely released)