### PR TITLE
Limit joblib version to pre-1.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ package_dir =
 python_requires = ~=3.6
 install_requires =
     appdirs == 1.*
-    joblib >= 0.17
+    joblib >= 0.17, < 1.1.0
 
 [options.extras_require]
 benchmarks =


### PR DESCRIPTION
joblib 1.1.0 was just released, and it broke fscacher.  This is a stopgap measure until a proper fix can be deployed.