### PR TITLE
Make versioneer.py use setuptools instead of distutils

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -1507,7 +1507,7 @@ def get_cmdclass(cmdclass=None):
     cmds = {} if cmdclass is None else cmdclass.copy()
 
     # we add "version" to both distutils and setuptools
-    from distutils.core import Command
+    from setuptools import Command
 
     class cmd_version(Command):
         description = "report generated version string"


### PR DESCRIPTION
[Distutils was officially deprecated in Python 3.10 and will be removed from the standard library completely in 3.12.](https://www.python.org/dev/peps/pep-0632/)  This PR thus removes the use of distutils from the code.