### PR TITLE
make joblib ignore "path" , pass resolved as part of the fingerprinting kwargs arg

### DIFF
--- a/src/fscacher/tests/test_cache.py
+++ b/src/fscacher/tests/test_cache.py
@@ -393,3 +393,25 @@ def test_follow_moved_symlink(cache, tmp_path):
     assert len(calls) == 1
     assert memoread(tmp_path / "subdir" / "text.txt") == content
     assert len(calls) == 1
+
+
+def test_memoize_path_nonpath_arg(cache, tmp_path):
+    calls = []
+
+    @cache.memoize_path
+    def memoread(filepath, arg, kwarg=None):
+        calls.append([filepath, arg, kwarg])
+        with open(filepath) as f:
+            return f.read()
+
+    path = str(tmp_path / "file.dat")
+    with open(path, "w") as f:
+        f.write("content")
+
+    time.sleep(cache._min_dtime * 1.1)
+
+    ncalls = len(calls)
+    assert memoread(path, 1) == "content"
+    assert len(calls) == ncalls + 1
+    assert memoread(arg=1, filepath=path) == "content"
+    assert len(calls) == ncalls + 1

--- a/src/fscacher/tests/test_cache.py
+++ b/src/fscacher/tests/test_cache.py
@@ -212,7 +212,7 @@ def test_memoize_path_dir(cache, tmp_path):
         # because distance is too short
         if time.time() - t0 < cache._min_dtime:
             raise  # if we were quick but still failed -- legit
-    assert calls[-1] == [str(path), 0, None]
+    assert calls[-1] == [path, 0, None]
 
     # but if we sleep - should memoize
     time.sleep(cache._min_dtime * 1.1)


### PR DESCRIPTION
Also includes fix to test_memoize_path_dir from #45 by @jwodder, which I
do not grasp necessity of yet in how it doesn't fail on master but fails with
these changes.

A minimalistic alternative to https://github.com/con/fscacher/pull/45
which fixes #44