### PR TITLE
Update Python version used to test development joblib to 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
                     - py
                 include:
                     - os: ubuntu-latest
-                      python-version: '3.6'
+                      python-version: '3.7'
                       toxenv: py-dev
                     - os: ubuntu-latest
                       python-version: '3.6'


### PR DESCRIPTION
The development version of joblib now requires Python 3.7 or higher.  If it releases any features we want to take advantage of, fscacher will need to drop support for 3.6 as well.