### PR TITLE
Support specifying a custom path for the cache; tokens becomes kwonly

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -81,13 +81,13 @@ jobs:
                 echo "ASV_PYTHON=$ASV_PYTHON" >> "$GITHUB_ENV"
 
             - name: Run benchmarks on newest code
-              run: asv run --python "$ASV_PYTHON" HEAD^-1
+              run: asv run --strict --show-stderr --python "$ASV_PYTHON" HEAD^-1
 
             - name: Check out previous code
               run: git checkout --force refs/bm/merge-target
 
             - name: Run benchmarks on previous code
-              run: asv run --python "$ASV_PYTHON" HEAD^-1
+              run: asv run --strict --show-stderr --python "$ASV_PYTHON" HEAD^-1
 
             - name: Compare benchmarks on previous & newest code
               run: asv compare refs/bm/merge-target refs/bm/pr

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,16 @@ Caches are stored on-disk and thus persist between Python runs.  To clear a
 given ``PersistentCache`` and erase its data store, call the ``clear()``
 method.
 
+By default, caches are stored in the user-wide cache directory, under an
+fscacher-specific folder, with each one identified by the name passed to the
+constructor (which defaults to "cache" if not specified).  To specify a
+different location, use the ``path`` argument to the constructor instead of
+passing a name:
+
+.. code:: python
+
+    cache = PersistentCache(path="/my/custom/location")
+
 If your code runs in an environment where different sets of libraries or the
 like could be used in different runs, and these make a difference to the output
 of your function, you can make the caching take them into account by passing a

--- a/benchmarks/cache.py
+++ b/benchmarks/cache.py
@@ -10,7 +10,6 @@ from fscacher import PersistentCache
 
 
 class TimeFile:
-
     FILE_SIZE = 1024
     param_names = ["control"]
     params = ["", "ignore"]
@@ -21,7 +20,7 @@ class TimeFile:
 
     def setup(self, control):
         with envset("FSCACHER_CACHE", control):
-            self.cache = PersistentCache(name=str(uuid4()))
+            self.cache = PersistentCache(path=str(uuid4()))
 
         @self.cache.memoize_path
         def hashfile(path):
@@ -52,7 +51,7 @@ class TimeDirectoryFlat:
     def setup(self, control, tmpdir):
         cache_id = str(uuid4())
         with envset("FSCACHER_CACHE", control):
-            self.cache = PersistentCache(name=cache_id)
+            self.cache = PersistentCache(path=cache_id)
         self.dir = Path(tmpdir, cache_id)
         self.dir.mkdir()
         create_tree(self.dir, self.LAYOUT)

--- a/benchmarks/cache.py
+++ b/benchmarks/cache.py
@@ -51,9 +51,9 @@ class TimeDirectoryFlat:
     def setup(self, control, tmpdir):
         cache_id = str(uuid4())
         with envset("FSCACHER_CACHE", control):
-            self.cache = PersistentCache(path=cache_id)
-        self.dir = Path(tmpdir, cache_id)
-        self.dir.mkdir()
+            self.cache = PersistentCache(path=os.path.join("cache", cache_id))
+        self.dir = Path(tmpdir, "work", cache_id)
+        self.dir.mkdir(parents=True)
         create_tree(self.dir, self.LAYOUT)
 
         @self.cache.memoize_path

--- a/src/fscacher/cache.py
+++ b/src/fscacher/cache.py
@@ -21,12 +21,18 @@ class PersistentCache(object):
 
     _cache_var_values = (None, "", "clear", "ignore")
 
-    def __init__(self, name=None, tokens=None, envvar=None):
+    def __init__(self, name=None, *, path=None, tokens=None, envvar=None):
         """
-
         Parameters
         ----------
-        name
+        name: str, optional
+         Basename for the directory in which to store the cache.  Mutually
+         exclusive with `path`.
+        path: str or pathlib.Path, optional
+         Directory path at which to store the cache.  If not specified, the
+         cache is stored in `USER_CACHE/fscacher/NAME`, where NAME is the value
+         of the `name` parameter (default: "cache").  Mutually exclusive with
+         `name`.
         tokens: list of objects, optional
          To add to the fingerprint of @memoize_path (regular @memoize ATM does
          not use it).  Could be e.g. versions of relevant/used
@@ -35,9 +41,12 @@ class PersistentCache(object):
          Name of the environment variable to query for cache settings; if not
          set, `FSCACHER_CACHE` is used
         """
-        dirs = appdirs.AppDirs("fscacher")
-        self._cache_file = op.join(dirs.user_cache_dir, (name or "cache"))
-        self._memory = joblib.Memory(self._cache_file, verbose=0)
+        if path is None:
+            dirs = appdirs.AppDirs("fscacher")
+            path = op.join(dirs.user_cache_dir, (name or "cache"))
+        elif name is not None:
+            raise ValueError("'name' and 'path' are mutually exclusive")
+        self._memory = joblib.Memory(path, verbose=0)
         cntrl_value = None
         if envvar is not None:
             cntrl_var = envvar


### PR DESCRIPTION
This PR adds a `path` argument to the `PersistentCache` constructor (mutually exclusive with `name`) that allows the caller to specify the desired location of the cache instead of creating it under an fscacher-specific folder in the user cache directory.  Among other benefits, this simplifies the management of caches while testing and benchmarking.