### PR TITLE
Make benchmarks measure cache misses and hits separately

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     asv
     virtualenv
 commands =
-    asv run {posargs}
+    asv run --strict {posargs} HEAD^1..HEAD
 
 [pytest]
 addopts = --cov=fscacher --no-cov-on-fail
@@ -57,6 +57,7 @@ doctests = True
 exclude = .*/,build/,dist/,test/data,venv/,_version.py
 import-order-style = jwodder
 max-line-length = 88
+unused-arguments-ignore-stub-functions = True
 select = C,B,B902,B950,E,F,U100,W
 extend-ignore = B005,E203
 


### PR DESCRIPTION
Cache population/misses and cache hits are different animals with different expected runtimes, and thus they should be measured separately.