### PR TITLE
Ignore cache for non-path-like arguments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,24 +2,24 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 23.1.0
     hooks:
     -   id: black
         exclude: ^(src/fscacher/_version\.py|versioneer\.py)$
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
     -   id: isort
         exclude: ^(src/fscacher/_version\.py|versioneer\.py)$
 -   repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,8 @@ Now the outputs of ``foo()`` will be cached for each set of input arguments and
 for a "fingerprint" (timestamps & size) of each ``path``.  If ``foo()`` is
 called twice with the same set of arguments, the result from the first call
 will be reused for the second, unless the file pointed to by ``path`` changes,
-in which case the function will be run again.
+in which case the function will be run again.  If ``foo()`` is called with a
+non-path-like object as the value of ``path``, the cache is ignored.
 
 Caches are stored on-disk and thus persist between Python runs.  To clear a
 given ``PersistentCache`` and erase its data store, call the ``clear()``

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,9 @@ for a "fingerprint" (timestamps & size) of each ``path``.  If ``foo()`` is
 called twice with the same set of arguments, the result from the first call
 will be reused for the second, unless the file pointed to by ``path`` changes,
 in which case the function will be run again.  If ``foo()`` is called with a
-non-path-like object as the value of ``path``, the cache is ignored.
+non-`path-like object
+<https://docs.python.org/3/glossary.html#term-path-like-object>`_ as the value
+of ``path``, the cache is ignored.
 
 Caches are stored on-disk and thus persist between Python runs.  To clear a
 given ``PersistentCache`` and erase its data store, call the ``clear()``

--- a/benchmarks/cache.py
+++ b/benchmarks/cache.py
@@ -18,6 +18,7 @@ class BaseCacheBenchmark(ABC):
         # Must return the path created
         ...
 
+    @staticmethod
     @abstractmethod
     def init_func(cache):
         # Must return the function

--- a/src/fscacher/cache.py
+++ b/src/fscacher/cache.py
@@ -121,7 +121,11 @@ class PersistentCache(object):
             bound = sig.bind(*args, **kwargs)
             bound.apply_defaults()
             path_orig = bound.arguments[path_arg]
-            path = op.realpath(path_orig)
+            try:
+                path = op.realpath(path_orig)
+            except TypeError:
+                lgr.debug("Argument is not a path-like object; bypassing cache")
+                return f(*args, **kwargs)
             if path != path_orig:
                 lgr.log(5, "Dereferenced %r into %r", path_orig, path)
             if op.isdir(path):

--- a/src/fscacher/cache.py
+++ b/src/fscacher/cache.py
@@ -124,7 +124,9 @@ class PersistentCache(object):
             try:
                 path = op.realpath(path_orig)
             except TypeError:
-                lgr.debug("Argument is not a path-like object; bypassing cache")
+                lgr.debug(
+                    "Calling %s directly since argument is not a path-like object", f
+                )
                 return f(*args, **kwargs)
             if path != path_orig:
                 lgr.log(5, "Dereferenced %r into %r", path_orig, path)

--- a/src/fscacher/cache.py
+++ b/src/fscacher/cache.py
@@ -15,8 +15,7 @@ lgr = logging.getLogger(__name__)
 
 
 class PersistentCache(object):
-    """Persistent cache providing @memoize and @memoize_path decorators
-    """
+    """Persistent cache providing @memoize and @memoize_path decorators"""
 
     _min_dtime = 0.01  # min difference between now and mtime to consider
     # for caching
@@ -158,8 +157,7 @@ class PersistentCache(object):
 
     @staticmethod
     def _get_file_fingerprint(path):
-        """Simplistic generic file fingerprinting based on ctime, mtime, and size
-        """
+        """Simplistic generic file fingerprinting based on ctime, mtime, and size"""
         try:
             # we can't take everything, since atime can change, etc.
             # So let's take some

--- a/src/fscacher/tests/test_cache.py
+++ b/src/fscacher/tests/test_cache.py
@@ -1,5 +1,7 @@
+from dataclasses import dataclass
 import os
 import os.path as op
+from pathlib import Path
 import platform
 import shutil
 import subprocess
@@ -454,3 +456,51 @@ def test_memoize_non_pathlike_arg(cache, tmp_path):
 
     assert strify(42) == "42"
     assert calls == [path, 42, 42]
+
+
+@dataclass
+class PathWrapper:
+    path: Path
+
+    def __fspath__(self) -> str:
+        return str(self.path)
+
+    def __str__(self) -> str:
+        return str(self.path)
+
+
+def test_memoize_pathlike_arg(cache, tmp_path):
+    calls = []
+
+    @cache.memoize_path
+    def strify(x):
+        calls.append(x)
+        return str(x)
+
+    path = tmp_path / "foo"
+    path.touch()
+    foo = PathWrapper(path)
+
+    path2 = tmp_path / "bar"
+    path2.touch()
+    bar = PathWrapper(path2)
+
+    time.sleep(cache._min_dtime * 1.1)
+
+    assert strify(path) == str(path)
+    assert calls == [path]
+
+    assert strify(foo) == str(path)
+    assert calls == [path]
+
+    assert strify(bar) == str(tmp_path / "bar")
+    assert calls == [path, bar]
+
+    assert strify(path) == str(path)
+    assert calls == [path, bar]
+
+    assert strify(foo) == str(path)
+    assert calls == [path, bar]
+
+    assert strify(bar) == str(tmp_path / "bar")
+    assert calls == [path, bar]

--- a/src/fscacher/tests/test_cache.py
+++ b/src/fscacher/tests/test_cache.py
@@ -429,3 +429,28 @@ def test_dir_fingerprint_order_irrelevant(tmp_path):
         df_tuples.append(dprint.to_tuple())
     for i in range(1, len(df_tuples)):
         assert df_tuples[0] == df_tuples[i]
+
+
+def test_memoize_non_pathlike_arg(cache, tmp_path):
+    calls = []
+
+    @cache.memoize_path
+    def strify(x):
+        calls.append(x)
+        return str(x)
+
+    path = tmp_path / "foo"
+    path.touch()
+    time.sleep(cache._min_dtime * 1.1)
+
+    assert strify(path) == str(path)
+    assert calls == [path]
+
+    assert strify(42) == "42"
+    assert calls == [path, 42]
+
+    assert strify(path) == str(path)
+    assert calls == [path, 42]
+
+    assert strify(42) == "42"
+    assert calls == [path, 42, 42]

--- a/tox.ini
+++ b/tox.ini
@@ -7,17 +7,17 @@ minversion = 3.3.0
 [testenv]
 deps =
     dev: joblib @ git+https://github.com/joblib/joblib.git
-    pytest~=6.0
-    pytest-cov~=2.0
-    pytest-mock~=3.0
+    pytest
+    pytest-cov
+    pytest-mock
 commands =
     pytest --pyargs {posargs} fscacher
 
 [testenv:lint]
 deps =
-    flake8~=4.0
+    flake8
     flake8-bugbear
-    flake8-builtins~=1.4
+    flake8-builtins
     flake8-unused-arguments
 commands =
     flake8 benchmarks src
@@ -44,7 +44,7 @@ parallel = True
 [coverage:paths]
 source =
     src
-    .tox/*/site-packages
+    .tox/**/site-packages
 
 [coverage:report]
 precision = 2
@@ -52,14 +52,13 @@ show_missing = True
 omit = src/fscacher/_version.py
 
 [flake8]
-application-import-names = fscacher
 doctests = True
 exclude = .*/,build/,dist/,test/data,venv/,_version.py
-import-order-style = jwodder
+hang-closing = False
 max-line-length = 88
 unused-arguments-ignore-stub-functions = True
-select = C,B,B902,B950,E,F,U100,W
-extend-ignore = B005,E203
+select = A,B,B902,B950,C,E,E242,F,U100,W
+ignore = B005,E203,E262,E266,E501,W503
 
 [isort]
 atomic = True


### PR DESCRIPTION
As discussed at https://github.com/dandi/dandi-cli/issues/1196#issuecomment-1434707000.