### PR TITLE
Use Python 3.8 to test against dev version of joblib

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
                     - py
                 include:
                     - os: ubuntu-latest
-                      python-version: '3.7'
+                      python-version: '3.8'
                       toxenv: py-dev
                     - os: ubuntu-latest
                       python-version: '3.7'


### PR DESCRIPTION
The dev version of joblib requires Python 3.8+.