### PR TITLE
centralize testing depends in setup.cfg extra depends

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
 benchmarks =
     asv[virtualenv] ~= 0.6.0, < 0.6.2
 test =
+    pytest
     pytest-cov
     pytest-mock
     pytest-rerunfailures

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,8 +47,13 @@ install_requires =
 [options.extras_require]
 benchmarks =
     asv[virtualenv] ~= 0.6.0, < 0.6.2
+test =
+    pytest-cov
+    pytest-mock
+    pytest-rerunfailures
 devel =
     %(benchmarks)s
+    %(test)s
     pre-commit
 all =
     %(devel)s

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,8 @@ minversion = 3.3.0
 [testenv]
 deps =
     dev: joblib @ git+https://github.com/joblib/joblib.git
-    pytest
-    pytest-cov
-    pytest-mock
-    pytest-rerunfailures
+extras =
+    test
 commands =
     pytest --pyargs {posargs} fscacher
 


### PR DESCRIPTION
Extended reasoning for moving definition to setup.cfg is in the last commit:  ATM f394f3082eabedda4cd6da18941d67b082837176 , cited here:

# extras test vs tox.ini:

Most recent debate on tox.ini vs extra_depends is at
https://github.com/con/solidation/pull/43#discussion_r1725031914

Although I appreciate the convenience of "tox" as an entry point for testing, I
increasingly find no support for it to be "the" location for testing depends
listing. Moreover I keep running into cases of needing to fish out test
dependencies somewhere else (tox.ini, nox etc) which then can differ across
projects, and also require me to adopt some avoidable runtime etc overhead from
running those extra test shims whenever pytest is just good enough.

My arguments for generally adopting an approach of specifying test
dependencies in setup.{cfg,py} or other "generic" locations as optional are:

- pytest, and its extentions are used (imported) inside the tests.  I, in 99%
  of cases, do consider "tests" to be the part of the source code.  I would not
  consider them part of the source code whenever there is an outside test
  battery which is developed/maintained independently of the source code.

  As such, I think that dependencies for tests, as part of the source code,
  should be listed alongside with dependencies for the build/installation/run
  time dependencies.  Some distributions even do "import test" across entire
  source code distribution and thus tend to decide or to request exclusion from
  source distributions (IMHO the wrong step in most of the cases).
  Ref: https://github.com/dandi/dandi-schema/pull/249

- It is unfortunate that there is no "standard" convention on how/where to
  specify such test requirements, so I think it is ok to adopt [test] as
  the general convention among our projects.

- tox.ini looses NOTHING from using "extras".

- tox.ini is the correct location to describe environments and dependncies
  for external to source code tools/modules, i.e those not imported explicitly
  anywhere in the source code.

- with description of test dependencies alongside with the main dependencies
  would benefit downstream distribution (debian, conda, gentoo, etc)
  packagers since they do not need to fish around for what other dependencies
  to install/recommend/suggest for the package.

- I do appreciate the fact that test dependencies alone are not sufficient to
  run the tests, but invocation of the pytest is standardized enough to just
  invoke it against the source code. (given dependencies are installed)

  That is e.g. how dh-python helper in Debian operates -- if pytest dependency
  announced, just run pytest automagically.
