### PR TITLE
BF: force "little" endianness while xor_byte

### DIFF
--- a/src/fscacher/cache.py
+++ b/src/fscacher/cache.py
@@ -6,7 +6,6 @@ import logging
 import os
 import os.path as op
 import shutil
-import sys
 import time
 import joblib
 from platformdirs import PlatformDirs
@@ -247,9 +246,11 @@ class DirFingerprint:
 
 def xor_bytes(b1: bytes, b2: bytes) -> bytes:
     length = max(len(b1), len(b2))
-    i1 = int.from_bytes(b1, sys.byteorder)
-    i2 = int.from_bytes(b2, sys.byteorder)
-    return (i1 ^ i2).to_bytes(length, sys.byteorder)
+    # force 'little' byte order to match our assumptions on how to
+    # treat bytes of different length.
+    i1 = int.from_bytes(b1, "little")
+    i2 = int.from_bytes(b2, "little")
+    return (i1 ^ i2).to_bytes(length, "little")
 
 
 def elapsed_since(t: float) -> float:

--- a/src/fscacher/tests/test_util.py
+++ b/src/fscacher/tests/test_util.py
@@ -1,6 +1,5 @@
 from itertools import zip_longest
 import pytest
-
 from ..cache import xor_bytes
 
 

--- a/src/fscacher/tests/test_util.py
+++ b/src/fscacher/tests/test_util.py
@@ -1,4 +1,6 @@
+from itertools import zip_longest
 import pytest
+
 from ..cache import xor_bytes
 
 
@@ -13,4 +15,6 @@ from ..cache import xor_bytes
     ],
 )
 def test_xor_bytes(b1: bytes, b2: bytes, r: bytes) -> None:
+    # test the target value assumption
+    assert r == bytes(x ^ y for x, y in zip_longest(b1, b2, fillvalue=0))
     assert xor_bytes(b1, b2) == r


### PR DESCRIPTION
We are using xor_byte for fingerprint computation and need to
also handle bytes of different length.  When working on big-endian
platforms (such as the only one left s390x on debian) our assumptions
of alignment of bytes in such strings fail. For consistency - always
do it "little endian" way

I also added "testing" for the expectation of the target value, so easy to discern desired logic for xor'ed value construction.

Closes #101 